### PR TITLE
Set broadcast flag for UDP client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+WORKDIR /src
+COPY MagicPacket/MagicPacket.csproj MagicPacket/
+RUN dotnet restore MagicPacket/MagicPacket.csproj
+COPY MagicPacket/ MagicPacket/
+WORKDIR /src/MagicPacket
+RUN dotnet publish MagicPacket.csproj -c Release -o /app/publish /p:UseAppHost=false
+
+FROM mcr.microsoft.com/dotnet/runtime:6.0 AS final
+WORKDIR /app
+COPY --from=build /app/publish .
+ENTRYPOINT ["dotnet", "MagicPacket.dll"]

--- a/MagicPacket/Program.cs
+++ b/MagicPacket/Program.cs
@@ -14,7 +14,10 @@ void SendMagicPacket(string macAddress, string ipAddress, int port)
     for (int i = 6; i < packet.Length; i += 6)
         Buffer.BlockCopy(macBytes, 0, packet, i, 6);
 
-    var client = new UdpClient(ipAddress, port);
+    using var client = new UdpClient(ipAddress, port)
+    {
+        EnableBroadcast = true
+    };
 
     client.Send(packet, packet.Length);
 }


### PR DESCRIPTION
## Summary
- enable `UdpClient.EnableBroadcast` when sending Wake-on-LAN packets
- dispose of `UdpClient` via `using` statement
- add Dockerfile providing the .NET SDK so containers have access to `dotnet`

## Testing
- `dotnet build MagicPacket/MagicPacket.csproj -c Release` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_68409983f2688329b325ba4d43d76da7