### PR TITLE
Fetch MAC and IP from DNS TXT record

### DIFF
--- a/MagicPacket/Program.cs
+++ b/MagicPacket/Program.cs
@@ -1,10 +1,49 @@
-﻿using System.Net.Sockets;
+using System.Diagnostics;
+using System.Net.Sockets;
+using System.Globalization;
 
-SendMagicPacket("MAC:ADDRESS:GOES:HERE", "IP.ADDRESS.GOES.HERE", 7);
-    
-void SendMagicPacket(string macAddress, string ipAddress, int port)
+string domain = args.Length > 0 ? args[0] : Environment.GetEnvironmentVariable("MAGICPACKET_DNS") ?? "wol.example.com";
+
+(string macAddress, string ipAddress) = ResolveParameters(domain);
+
+SendMagicPacket(macAddress, ipAddress, 7);
+
+static (string mac, string ip) ResolveParameters(string domain)
 {
-    var macBytes = macAddress.Split(':').Select(x => byte.Parse(x, System.Globalization.NumberStyles.HexNumber)).ToArray();
+    var psi = new ProcessStartInfo("nslookup", $"-type=TXT {domain}")
+    {
+        RedirectStandardOutput = true,
+        UseShellExecute = false
+    };
+    using var process = Process.Start(psi)!;
+    string output = process.StandardOutput.ReadToEnd();
+    process.WaitForExit();
+
+    string mac = string.Empty;
+    string ip = string.Empty;
+
+    foreach (var line in output.Split('\n'))
+    {
+        var trimmed = line.Trim();
+        if (trimmed.Contains("text ="))
+        {
+            var text = trimmed.Substring(trimmed.IndexOf("text =") + 6).Trim().Trim('"');
+            foreach (var token in text.Split(new[] {' ', ','}, StringSplitOptions.RemoveEmptyEntries))
+            {
+                if (token.StartsWith("mac=", StringComparison.OrdinalIgnoreCase))
+                    mac = token.Substring(4);
+                else if (token.StartsWith("ip=", StringComparison.OrdinalIgnoreCase))
+                    ip = token.Substring(3);
+            }
+        }
+    }
+
+    return (mac, ip);
+}
+
+static void SendMagicPacket(string macAddress, string ipAddress, int port)
+{
+    var macBytes = macAddress.Split(':').Select(x => byte.Parse(x, NumberStyles.HexNumber)).ToArray();
 
     var packet = new byte[6 + 16 * macBytes.Length];
 


### PR DESCRIPTION
## Summary
- read a TXT record with `nslookup` to obtain the MAC and IP
- use these values instead of hard-coded ones

## Testing
- `dotnet build MagicPacket/MagicPacket.csproj --configuration Release`
- `dotnet MagicPacket/bin/Release/net8.0/MagicPacket.dll example.com` *(fails: input string not in correct format)*

------
https://chatgpt.com/codex/tasks/task_e_6840a03ff700832997c46be353b22ecf